### PR TITLE
refactor(generalize-data-access-interfaces): made data access interfaces inherit from general data access interface to prevent unnecessary parameters

### DIFF
--- a/src/main/java/use_case/DataAccessInterface.java
+++ b/src/main/java/use_case/DataAccessInterface.java
@@ -1,0 +1,3 @@
+package use_case;
+
+public interface DataAccessInterface {}

--- a/src/main/java/use_case/home/HomeDataAccessInterface.java
+++ b/src/main/java/use_case/home/HomeDataAccessInterface.java
@@ -1,9 +1,11 @@
 package use_case.home;
 
 import entities.Item;
+import use_case.DataAccessInterface;
+
 import java.io.IOException;
 import java.util.ArrayList;
 
-public interface HomeDataAccessInterface {
+public interface HomeDataAccessInterface extends DataAccessInterface {
     ArrayList<Item> getAllItems() throws IOException;
 }


### PR DESCRIPTION
This makes all Data Access Interfaces inherit from a general data access interface class to prevent inevitable future duplicate parameters in classes like Use Case factories.